### PR TITLE
Fixed JSON typo on Example 1 of conditions

### DIFF
--- a/powerbi-docs/developer/visuals/dataview-mappings.md
+++ b/powerbi-docs/developer/visuals/dataview-mappings.md
@@ -67,7 +67,7 @@ You can drag multiple fields into each data role. In this example, you limit the
 
 ```json
 "conditions": [
-    { "category": { "max": 1 }, "y": { "max": 2 } },
+    { "category": { "max": 1 }, "y": { "max": 2 } }
 ]
 ```
 


### PR DESCRIPTION
That trailing comma isn't valid.